### PR TITLE
auto-detect AES-NI hardware support on AMD64

### DIFF
--- a/aesni_amd64.go
+++ b/aesni_amd64.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 Minio Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build amd64,!gccgo,!appengine
+
+package sio
+
+//go:noescape
+func hasAESNISupport() bool

--- a/aesni_amd64.s
+++ b/aesni_amd64.s
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Minio Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build amd64,!gccgo,!appengine
+
+#include "textflag.h"
+
+// func hasAESNISupport() bool
+TEXT ·hasAESNISupport(SB),NOSPLIT,$0
+	XORQ AX, AX
+	INCL AX
+	CPUID
+	SHRQ $25, CX
+	ANDQ $1, CX
+	MOVB CX, ret+0(FP)
+	RET

--- a/aesni_generic.go
+++ b/aesni_generic.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 Minio Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !amd64 gccgo appengine
+
+package sio
+
+func hasAESNISupport() bool { return false }

--- a/dare.go
+++ b/dare.go
@@ -188,7 +188,7 @@ func setConfigDefaults(config *Config) error {
 		return errors.New("sio: unknown minimum version")
 	}
 	if config.MaxVersion > Version10 {
-		return errors.New("dare: unknown maximum version")
+		return errors.New("sio: unknown maximum version")
 	}
 	if len(config.Key) != 32 {
 		return errors.New("sio: invalid key size")

--- a/dare.go
+++ b/dare.go
@@ -208,12 +208,19 @@ func setConfigDefaults(config *Config) error {
 		config.MaxVersion = config.MinVersion
 	}
 	if len(config.CipherSuites) == 0 {
-		config.CipherSuites = []byte{AES_256_GCM, CHACHA20_POLY1305}
+		config.CipherSuites = defaultCipherSuites()
 	}
 	if config.Rand == nil {
 		config.Rand = rand.Reader
 	}
 	return nil
+}
+
+func defaultCipherSuites() []byte {
+	if hasAESNISupport() {
+		return []byte{AES_256_GCM, CHACHA20_POLY1305}
+	}
+	return []byte{CHACHA20_POLY1305, AES_256_GCM}
 }
 
 // Config contains the format configuration. The only field


### PR DESCRIPTION
This change detects whether AES-NI are supported on AMD64. If so it sets the default cipher suite to AES-256_GCM. Otherwise it sets the default to ChaCha20Poly1305.

Fixes #7 