### PR TITLE
add an error type representing decryption failure

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -87,7 +87,11 @@ func ExampleDecrypt() {
 	output := os.Stdout // customize from your needs - the decrypted output
 
 	if _, err = Decrypt(output, input, Config{Key: key[:]}); err != nil {
-		fmt.Printf("Failed to encrypt data: %v", err) // add error handling
+		if _, ok := err.(Error); ok {
+			fmt.Printf("Malformed encrypted data: %v", err) // add error handling - here we know that the data is malformed/not authentic.
+			return
+		}
+		fmt.Printf("Failed to decrypt data: %v", err) // add error handling
 		return
 	}
 }

--- a/writer-v2.go
+++ b/writer-v2.go
@@ -52,7 +52,7 @@ func (w *encWriterV20) Write(p []byte) (n int, err error) {
 	}
 	if w.offset > 0 { // buffer the plaintext data
 		remaining := maxPayloadSize - w.offset
-		if len(p) <= remaining { // <= is important here to buffer up to 64 KB (inclusivly) - see: Close()
+		if len(p) <= remaining { // <= is important here to buffer up to 64 KB (inclusively) - see: Close()
 			w.offset += copy(w.buffer[headerSize+w.offset:], p)
 			return len(p), nil
 		}


### PR DESCRIPTION
This commit adds an error type: sio.Error. It is returned
by an io.Reader / io.Writer if the decryption failed. A type check
can be used to distingush a decryption error from other reading/writing
errors like network errors, short buffer errors, ...

Fixes #24