### PR TITLE
ncrypt: read password from file and fix return code when failed

### DIFF
--- a/cmd/ncrypt/main.go
+++ b/cmd/ncrypt/main.go
@@ -59,9 +59,10 @@ var (
 )
 
 var (
-	listFlag    bool
-	decryptFlag bool
-	cipherFlag  string
+	listFlag     bool
+	decryptFlag  bool
+	cipherFlag   string
+	passwordFlag string
 )
 
 func init() {
@@ -69,6 +70,7 @@ func init() {
 	flag.BoolVar(&decryptFlag, "d", false, fmt.Sprintf("%-8s Decrypt", ""))
 
 	flag.StringVar(&cipherFlag, "cipher", "", fmt.Sprintf("%-8s Specify cipher - default: platform depended", "string"))
+	flag.StringVar(&passwordFlag, "p", "", fmt.Sprintf("%-8s Specify the password - default: prompt for password", "string"))
 
 	flag.Usage = func() {
 		printFlag := func(f *flag.Flag) {
@@ -224,7 +226,9 @@ func readPassword(src *os.File) []byte {
 
 func deriveKey(dst, src *os.File) []byte {
 	password, salt := []byte{}, make([]byte, 32)
-	if src == os.Stdin {
+	if passwordFlag != "" {
+		password = []byte(passwordFlag)
+	} else if src == os.Stdin {
 		password = readPassword(os.Stderr)
 	} else {
 		password = readPassword(os.Stdin)

--- a/cmd/ncrypt/main.go
+++ b/cmd/ncrypt/main.go
@@ -217,7 +217,7 @@ func readPassword(src *os.File) []byte {
 	fmt.Fprintln(src, "")
 	if len(password) == 0 {
 		fmt.Fprintln(os.Stderr, "Failed to read password: No password")
-		exit(codeOK)
+		exit(codeError)
 	}
 	return password
 }


### PR DESCRIPTION
This PR contains two commits:
1. The first one fixes the return code when fail to read the password
2. ~~The second one adds the `-password-file` flag to support reading the password from a file.~~
2. The second one adds the `-p` flag to support specifying the password.