### PR TITLE
ncrypt: add missinsg help field in package documentation

### DIFF
--- a/cmd/ncrypt/main.go
+++ b/cmd/ncrypt/main.go
@@ -22,7 +22,7 @@
 //    -cipher string   Specify cipher - default: platform depended
 //    -d               Decrypt
 //    -list            List supported algorithms
-//
+//    -p      string   Specify the password - default: prompt for password
 //
 // Examples:
 //


### PR DESCRIPTION
The package documentation contained an out of date helptext (-h)