### PR TITLE
add `DecryptReaderAt` implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ env:
 - ARCH=i686
 
 go:
-- "1.8.7"
-- "1.9.4"
-- "1.10"
+- "1.12"
+- "1.13"
 
 script:
 - diff -au <(gofmt -d .) <(printf "")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/minio/sio
 
 require (
-	golang.org/x/crypto v0.0.0-20181106171534-e4dc69e5b2fd
-	golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8
+	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
+	golang.org/x/sys v0.0.0-20190412213103-97732733099d
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
-golang.org/x/crypto v0.0.0-20181106171534-e4dc69e5b2fd h1:VtIkGDhk0ph3t+THbvXHfMZ8QHgsBO39Nh52+74pq7w=
-golang.org/x/crypto v0.0.0-20181106171534-e4dc69e5b2fd/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8 h1:YoY1wS6JYVRpIfFngRf2HHo9R9dAne3xbkGOQ5rJXjU=
-golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f h1:R423Cnkcp5JABoeemiGEPlt9tHXFfw5kvc0yqlxRPWo=
+golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/reader-v2.go
+++ b/reader-v2.go
@@ -15,7 +15,10 @@
 package sio
 
 import (
+	"errors"
 	"io"
+	"io/ioutil"
+	"sync"
 )
 
 type encReaderV20 struct {
@@ -175,4 +178,81 @@ func (r *decReaderV20) Read(p []byte) (n int, err error) {
 		}
 	}
 	return n, nil
+}
+
+type decReaderAtV20 struct {
+	src io.ReaderAt
+
+	ad      authDecV20
+	bufPool sync.Pool
+}
+
+// decryptReaderAtV20 returns an io.ReaderAt wrapping the given io.ReaderAt.
+// The returned io.ReaderAt decrypts everything it reads using DARE 2.0.
+func decryptReaderAtV20(src io.ReaderAt, config *Config) (*decReaderAtV20, error) {
+	ad, err := newAuthDecV20(config)
+	if err != nil {
+		return nil, err
+	}
+	r := &decReaderAtV20{
+		ad:  ad,
+		src: src,
+	}
+	r.bufPool = sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, maxPackageSize)
+			return &b
+		},
+	}
+	return r, nil
+}
+
+func (r *decReaderAtV20) ReadAt(p []byte, offset int64) (n int, err error) {
+	if offset < 0 {
+		return 0, errors.New("sio: DecReaderAt.ReadAt: offset is negative")
+	}
+
+	t := offset / int64(maxPayloadSize)
+	if t+1 > (1<<32)-1 {
+		return 0, errUnexpectedSize
+	}
+
+	buffer := r.bufPool.Get().(*[]byte)
+	defer r.bufPool.Put(buffer)
+	decReader := decReaderV20{
+		authDecV20: r.ad,
+		src:        &sectionReader{r.src, t * maxPackageSize},
+		buffer:     packageV20(*buffer),
+		offset:     0,
+	}
+	decReader.SeqNum = uint32(t)
+	if k := offset % int64(maxPayloadSize); k > 0 {
+		if _, err := io.CopyN(ioutil.Discard, &decReader, k); err != nil {
+			return 0, err
+		}
+	}
+
+	for n < len(p) && err == nil {
+		var nn int
+		nn, err = (&decReader).Read(p[n:])
+		n += nn
+	}
+	if err == io.EOF && n == len(p) {
+		err = nil
+	}
+	return n, err
+}
+
+// Use a custom sectionReader since io.SectionReader
+// demands a read limit.
+
+type sectionReader struct {
+	r   io.ReaderAt
+	off int64
+}
+
+func (r *sectionReader) Read(p []byte) (int, error) {
+	n, err := r.r.ReadAt(p, r.off)
+	r.off += int64(n)
+	return n, err
 }

--- a/sio.go
+++ b/sio.go
@@ -224,6 +224,23 @@ func DecryptReader(src io.Reader, config Config) (io.Reader, error) {
 	return decryptReader(src, &config), nil
 }
 
+// DecryptReaderAt wraps the given src and returns an io.ReaderAt which decrypts
+// all received data. DecryptReaderAt returns an error if the provided decryption
+// configuration is invalid. The returned io.ReaderAt returns an error of
+// type sio.Error if the decryption fails.
+func DecryptReaderAt(src io.ReaderAt, config Config) (io.ReaderAt, error) {
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	if config.MinVersion == Version10 && config.MaxVersion == Version10 {
+		return decryptReaderAtV10(src, &config)
+	}
+	if config.MinVersion == Version20 && config.MaxVersion == Version20 {
+		return decryptReaderAtV20(src, &config)
+	}
+	return decryptReaderAt(src, &config), nil
+}
+
 // EncryptWriter wraps the given dst and returns an io.WriteCloser which
 // encrypts all data written to it. EncryptWriter returns an error if the
 // provided decryption configuration is invalid.


### PR DESCRIPTION
This commit adds a `ReaderAt` implementation that
allows decrypting a data using random access patterns.

With `DecryptReaderAt` it is possible to decrypt an `io.ReaderAt`
and reading from arbitrary (plaintext) offsets.