### PR TITLE
Add DecryptBuffer for small payloads

### DIFF
--- a/reader-v2.go
+++ b/reader-v2.go
@@ -180,6 +180,36 @@ func (r *decReaderV20) Read(p []byte) (n int, err error) {
 	return n, nil
 }
 
+// decryptBufferV20 will append plaintext to dst and return the result.
+func decryptBufferV20(dst, src []byte, config *Config) ([]byte, error) {
+	ad, err := newAuthDecV20(config)
+	if err != nil {
+		return nil, err
+	}
+	for len(src) > 0 {
+		buffer := packageV20(src)
+		// Truncate to max package size
+		if len(buffer) > maxPackageSize {
+			buffer = buffer[:maxPackageSize]
+		}
+
+		// Make space in dst
+		payloadLen := buffer.Header().Length()
+		dst = append(dst, make([]byte, payloadLen)...)
+
+		// Write directly to dst.
+		if err = ad.Open(dst[len(dst)-payloadLen:], buffer); err != nil {
+			return nil, err // decryption failed
+		}
+		// Forward to next block.
+		src = src[buffer.Length():]
+	}
+	if !ad.finalized {
+		return nil, errUnexpectedEOF
+	}
+	return dst, nil
+}
+
 type decReaderAtV20 struct {
 	src io.ReaderAt
 

--- a/reader-v2.go
+++ b/reader-v2.go
@@ -195,7 +195,7 @@ func decryptBufferV20(dst, src []byte, config *Config) ([]byte, error) {
 
 		// Make space in dst
 		payloadLen := buffer.Header().Length()
-		if cap(dst) <= len(dst)+payloadLen {
+		if cap(dst) >= len(dst)+payloadLen {
 			dst = dst[:len(dst)+payloadLen]
 		} else {
 			dst = append(dst, make([]byte, payloadLen)...)

--- a/reader-v2.go
+++ b/reader-v2.go
@@ -195,7 +195,11 @@ func decryptBufferV20(dst, src []byte, config *Config) ([]byte, error) {
 
 		// Make space in dst
 		payloadLen := buffer.Header().Length()
-		dst = append(dst, make([]byte, payloadLen)...)
+		if cap(dst) <= len(dst)+payloadLen {
+			dst = dst[:len(dst)+payloadLen]
+		} else {
+			dst = append(dst, make([]byte, payloadLen)...)
+		}
 
 		// Write directly to dst.
 		if err = ad.Open(dst[len(dst)-payloadLen:], buffer); err != nil {

--- a/sio_test.go
+++ b/sio_test.go
@@ -136,6 +136,68 @@ func TestEncrypt(t *testing.T) {
 	}
 }
 
+func TestDecryptBuffer(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		t.Fatalf("Failed to generate random key: %v", err)
+	}
+	config := Config{Key: key}
+
+	for _, version := range versions {
+		t.Run(fmt.Sprintf("v-%x", version), func(t *testing.T) {
+
+			config.MinVersion, config.MaxVersion = version, version
+			for i, test := range ioTests {
+				t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+
+					data := make([]byte, test.datasize)
+					if _, err := io.ReadFull(rand.Reader, data); err != nil {
+						t.Fatalf("Version %d: Test %d: Failed to generate random data: %v", version, i, err)
+					}
+
+					output := bytes.NewBuffer(nil)
+
+					if _, err := Encrypt(output, bytes.NewReader(data), config); err != nil {
+						t.Errorf("Version %d: Test %d: Encryption failed: %v", version, i, err)
+					}
+					// dumpDareStream(output.Bytes())
+					decrypted, err := DecryptBuffer(make([]byte, 0, output.Len()), output.Bytes(), config)
+					if len(decrypted) != test.datasize || err != nil {
+						t.Errorf("Version %d: Test %d: Decryption failed: number of bytes: %d vs. %d - %v", version, i, len(decrypted), test.datasize, err)
+						return
+					}
+					if !bytes.Equal(data, decrypted) {
+						t.Errorf("Version %d: Test: %d: Failed to encrypt and decrypt data", version, i)
+					}
+
+					// Test with existing data.
+					decrypted, err = DecryptBuffer(make([]byte, 500, output.Len()+500), output.Bytes(), config)
+					if err != nil {
+						t.Errorf("Version %d: Test %d: Decryption failed: number of bytes: %d vs. %d - %v", version, i, len(decrypted), test.datasize, err)
+						return
+					}
+					if len(decrypted) != test.datasize+500 {
+						t.Errorf("Version %d: Test %d: Decryption failed: number of bytes: %d vs. %d - %v", version, i, len(decrypted), test.datasize, err)
+						return
+					}
+					if !bytes.Equal(decrypted[:500], make([]byte, 500)) {
+						t.Errorf("pre-output data was modified")
+						return
+					}
+					decrypted = decrypted[500:]
+					if len(decrypted) != test.datasize {
+						t.Errorf("Version %d: Test %d: Decryption failed: number of bytes: %d vs. %d - %v", version, i, len(decrypted), test.datasize, err)
+						return
+					}
+					if !bytes.Equal(data, decrypted) {
+						t.Errorf("Version %d: Test: %d: Failed to encrypt and decrypt data", version, i)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestReader(t *testing.T) {
 	config := Config{Key: make([]byte, 32)}
 	for _, version := range versions {

--- a/sio_test.go
+++ b/sio_test.go
@@ -171,7 +171,7 @@ func TestDecryptBuffer(t *testing.T) {
 					}
 
 					// Test with existing data.
-					decrypted, err = DecryptBuffer(make([]byte, 500, output.Len()+500), output.Bytes(), config)
+					decrypted, err = DecryptBuffer(make([]byte, 500, 500), output.Bytes(), config)
 					if err != nil {
 						t.Errorf("Version %d: Test %d: Decryption failed: number of bytes: %d vs. %d - %v", version, i, len(decrypted), test.datasize, err)
 						return


### PR DESCRIPTION
Adds a `DecryptBuffer` which will allow to decrypt smaller buffers without too much overhead.

There is fallback for the legacy DARE1 which doesn't benefit too much from this, but that can be added later if needed.