### PR TITLE
Add Flush to EncryptWriter

### DIFF
--- a/writer-v2.go
+++ b/writer-v2.go
@@ -80,6 +80,18 @@ func (w *encWriterV20) Write(p []byte) (n int, err error) {
 	return n, nil
 }
 
+func (w *encWriterV20) Flush() error {
+	if w.offset > 0 {
+		w.Seal(w.buffer, w.buffer[headerSize:headerSize+w.offset])
+		if err := flush(w.dst, w.buffer[:headerSize+w.offset]); err != nil { // write to underlying io.Writer
+			return err
+		}
+		w.offset = 0
+	}
+
+	return nil
+}
+
 func (w *encWriterV20) Close() (err error) {
 	if w.buffer == nil {
 		return w.closeErr


### PR DESCRIPTION
The EncryptWriter type is great for encrypting streams of data but it lacks the ability
to flush data on disk periodically, to prevent losing data in case of a crash, which is
especially useful with databases.

This is a naive attempt to add a Flush method to EncryptWriter, merely done to start a
discussion on what would be the best approach to implement a proper one (as Github Issues
have been disabled).

If I understand correctly, the main problem here is that Flush cannot know beforehand 
if the last package should be sealed normally or finalized, which creates situations
where files are closed without being finalized.
Subsequent calls to ReadAt then return a "sio: invalid payload size" error.

Any idea on how I could improve this?