### PR TITLE
Allow for custom encoding nonce

### DIFF
--- a/dare.go
+++ b/dare.go
@@ -90,7 +90,9 @@ func newAuthEncV10(cfg *Config) (authEncV10, error) {
 		return authEncV10{}, err
 	}
 	var randVal [8]byte
-	if _, err = io.ReadFull(cfg.Rand, randVal[:]); err != nil {
+	if cfg.Nonce != nil {
+		copy(randVal[:], cfg.Nonce[:8])
+	} else if _, err = io.ReadFull(cfg.Rand, randVal[:]); err != nil {
 		return authEncV10{}, err
 	}
 	return authEncV10{
@@ -167,7 +169,9 @@ func newAuthEncV20(cfg *Config) (authEncV20, error) {
 		return authEncV20{}, err
 	}
 	var randVal [12]byte
-	if _, err = io.ReadFull(cfg.Rand, randVal[:]); err != nil {
+	if cfg.Nonce != nil {
+		randVal = *cfg.Nonce
+	} else if _, err = io.ReadFull(cfg.Rand, randVal[:]); err != nil {
 		return authEncV20{}, err
 	}
 	return authEncV20{

--- a/sio.go
+++ b/sio.go
@@ -122,6 +122,10 @@ type Config struct {
 	// the default value (crypto/rand.Reader) is used.
 	Rand io.Reader
 
+	// Nonce will override the nonce if set non-nil.
+	// V2 will use all 12 bytes, V1 first 8 bytes.
+	Nonce *[12]byte
+
 	// The size of the encrypted payload in bytes. The
 	// default value is 64KB. It should be used to restrict
 	// the size of encrypted packages. The payload size


### PR DESCRIPTION
To allow for optional deterministic output by allowing for a custom nonce to be set.