### PR TITLE
add ability to DecryptBuffer the middle of a stream

### DIFF
--- a/sio.go
+++ b/sio.go
@@ -118,6 +118,11 @@ type Config struct {
 	// stream.
 	SequenceNumber uint32
 
+	// The last expected sequence number. It should only
+	// be set manually when decrypting a range within a
+	// stream.
+	EndSequenceNumber *uint32
+
 	// The RNG used to generate random values. If not set
 	// the default value (crypto/rand.Reader) is used.
 	Rand io.Reader


### PR DESCRIPTION
Hello!

I'm in the need of decrypting ranges without using the `io.Reader`s provided, I ended up with this solution by adding an option in the `sio.Config`. If you have something better that comes to mind, I can draft it too!

I wrote the logic inside `dare.go` as it looked like the most "idiomatic" way of doing so in this repo (every function opening an AuthDec with the provided `sio.Config` -> then not touching the `sio.Config` again)

But if you prefer, I can limit the option to `decryptBufferV20()` by modifying:
```go
if !ad.finalized {
	return nil, errUnexpectedEOF
}
```
into something like:
```go
if !ad.finalized && (config != nil && config.EndSequenceNumber != nil && *config.EndSequenceNumber == ad.SeqNum-1) { 
	return nil, errUnexpectedEOF
}
```
But it's a bit more cryptic imho...

Thanks for your time reviewing this PR!