### PR TITLE
Make writers safe on Write-after-error

### DIFF
--- a/writer-v1.go
+++ b/writer-v1.go
@@ -49,6 +49,9 @@ func decryptWriterV10(dst io.Writer, config *Config) (*decWriterV10, error) {
 }
 
 func (w *decWriterV10) Write(p []byte) (n int, err error) {
+	if w.closeErr != nil {
+		return 0, w.closeErr
+	}
 	if w.offset > 0 && w.offset < headerSize { // buffer the header -> special code b/c we don't know when to decrypt without header
 		remaining := headerSize - w.offset
 		if len(p) < remaining {
@@ -178,6 +181,9 @@ func encryptWriterV10(dst io.Writer, config *Config) (*encWriterV10, error) {
 }
 
 func (w *encWriterV10) Write(p []byte) (n int, err error) {
+	if w.closeErr != nil {
+		return 0, w.closeErr
+	}
 	if w.offset > 0 { // buffer the plaintext
 		remaining := w.payloadSize - w.offset
 		if len(p) < remaining {

--- a/writer-v2.go
+++ b/writer-v2.go
@@ -49,6 +49,9 @@ func encryptWriterV20(dst io.Writer, config *Config) (*encWriterV20, error) {
 }
 
 func (w *encWriterV20) Write(p []byte) (n int, err error) {
+	if w.closeErr != nil {
+		return 0, w.closeErr
+	}
 	if w.finalized {
 		// The caller closed the encWriterV20 instance (called encWriterV20.Close()).
 		// This is a bug in the calling code - Write after Close is not allowed.
@@ -151,6 +154,9 @@ func decryptWriterV20(dst io.Writer, config *Config) (*decWriterV20, error) {
 }
 
 func (w *decWriterV20) Write(p []byte) (n int, err error) {
+	if w.closeErr != nil {
+		return 0, w.closeErr
+	}
 	if w.offset > 0 { // buffer package
 		remaining := headerSize + maxPayloadSize + tagSize - w.offset
 		if len(p) < remaining {


### PR DESCRIPTION
Writers will recycle the buffer when encountering an error. Doing another Write will use the recycled buffer.

While it isn't "nice" if a caller does writes after an error it still relies on this specific behaviour being respected.

Check the stateful error when writes arrive.